### PR TITLE
bcm53xx: linksys ea6500-v2: extend RAM to full 256MB

### DIFF
--- a/target/linux/bcm53xx/patches-5.10/315-ARM-dts-BCM5301X-Extend-RAM-to-full-256MB-for-Linksys-EA6500-V2.patch
+++ b/target/linux/bcm53xx/patches-5.10/315-ARM-dts-BCM5301X-Extend-RAM-to-full-256MB-for-Linksys-EA6500-V2.patch
@@ -1,0 +1,34 @@
+From b4b84e5cbd237347756e6c043d123065a62d4a84 Mon Sep 17 00:00:00 2001
+From: Aleksey Nasibulin <alealexpro100@ya.ru>
+Date: Sun, 14 Aug 2022 10:14:03 +0000
+Subject: [PATCH] ARM: dts: BCM5301X: Extend RAM to full 256MB for Linksys EA6500 V2
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Linksys ea6500-v2 have 256MB of ram. Currently we only use 128MB.
+Expand the definition to use all the available RAM.
+
+Fixes: 03e96644d7a8 ("ARM: dts: BCM5301X: Add basic DT for Linksys EA6500 V2")
+Signed-off-by: Aleksey Nasibulin <alealexpro100@ya.ru>
+---
+ arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts b/arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts
+index f1412ba83def..0454423fe166 100644
+--- a/arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts
++++ b/arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts
+@@ -19,7 +19,8 @@ chosen {
+ 
+ 	memory@0 {
+ 		device_type = "memory";
+-		reg = <0x00000000 0x08000000>;
++		reg = <0x00000000 0x08000000>,
++		      <0x88000000 0x08000000>;
+ 	};
+ 
+ 	gpio-keys {
+-- 
+2.37.1
+

--- a/target/linux/bcm53xx/patches-5.15/315-ARM-dts-BCM5301X-Extend-RAM-to-full-256MB-for-Linksys-EA6500-V2.patch
+++ b/target/linux/bcm53xx/patches-5.15/315-ARM-dts-BCM5301X-Extend-RAM-to-full-256MB-for-Linksys-EA6500-V2.patch
@@ -1,0 +1,34 @@
+From b4b84e5cbd237347756e6c043d123065a62d4a84 Mon Sep 17 00:00:00 2001
+From: Aleksey Nasibulin <alealexpro100@ya.ru>
+Date: Sun, 14 Aug 2022 10:14:03 +0000
+Subject: [PATCH] ARM: dts: BCM5301X: Extend RAM to full 256MB for Linksys EA6500 V2
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Linksys ea6500-v2 have 256MB of ram. Currently we only use 128MB.
+Expand the definition to use all the available RAM.
+
+Fixes: 03e96644d7a8 ("ARM: dts: BCM5301X: Add basic DT for Linksys EA6500 V2")
+Signed-off-by: Aleksey Nasibulin <alealexpro100@ya.ru>
+---
+ arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts b/arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts
+index f1412ba83def..0454423fe166 100644
+--- a/arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts
++++ b/arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts
+@@ -19,7 +19,8 @@ chosen {
+ 
+ 	memory@0 {
+ 		device_type = "memory";
+-		reg = <0x00000000 0x08000000>;
++		reg = <0x00000000 0x08000000>,
++		      <0x88000000 0x08000000>;
+ 	};
+ 
+ 	gpio-keys {
+-- 
+2.37.1
+


### PR DESCRIPTION
Linksys ea6500-v2 have 256MB of ram. Currently we only use 128MB. Expand the definition to use all the available RAM.

Signed-off-by: Aleksey Nasibulin <alealexpro100@ya.ru>
